### PR TITLE
Amend 2022-001 to guarantee Farer services are free

### DIFF
--- a/content/fedlex/2022-001.fr.md
+++ b/content/fedlex/2022-001.fr.md
@@ -34,7 +34,7 @@ Les membres de Farer ont le droit d’inviter n’importe qui au réseau Farer. 
 Les références qui enfreignent les politiques seront interdites au réseau Farer et leur adhésion révoquée. Le membre de référence pourrait être puni de la même façon s’il n’était pas au courant du réseau Farer et s’il pouvait prouver sans l’ombre d’un doute que le renvoi était intentionnel.
 
 ### Droit d'accès à Farer
-Les membres Farer ont le droit d’accéder aux services Farer à tout moment. L’accès aux services et aux contenus ne doit pas être empêché sur la base d’aucune discrimination, ni en fonction de la localisation géographique.
+Les membres Farer ont le droit d’accéder aux services Farer à tout moment. L’accès à tous les services et contenus ne doit pas être empêché sur la base d’aucune discrimination, ni en fonction de la localisation géographique. Les services fournis par The Farer Group ne peuvent pas nécessiter de paiement sous quelque forme que ce soit et doivent être également accessibles à tous les membres Farer.
 
 ### Right to vote or repeal policies
 Farer members have the right to vote on policies that have been proposed within the two-week window allotted. Members also have the right to vote to repeal a policy enacted.

--- a/content/fedlex/2022-001.fr.md
+++ b/content/fedlex/2022-001.fr.md
@@ -1,7 +1,7 @@
 +++
 title= "2022-001: Les droits et obligations des membres"
 date= "2022-11-09"
-updated= "2022-11-10"
+updated= "2022-12-04"
 +++
 
 ## Les droits des membres Farer

--- a/content/fedlex/2022-001.md
+++ b/content/fedlex/2022-001.md
@@ -34,7 +34,7 @@ Farer members have the right to invite any person into the Farer network. There 
 Referrals who break policies will be barred from the Farer network and their membership revoked. The referring member may face similar punishment for being unaware and barred from the Farer network if it can be proven without a doubt that the referral was with malicious intent.
 
 ### Right to access Farer
-Farer members have the right to access Farer services at any time. Access to services and content must not be prevented on the basis of any discrimination, nor based on geographical location.
+Farer members have the right to access Farer services at any time. Access to all services and content must not be prevented on the basis of any discrimination, nor based on geographical location. Services provided by The Farer Group cannot require payment in any shape and must be equally accessible by all Farer members.
 
 ### Right to vote or repeal policies
 Farer members have the right to vote on policies that have been proposed within the two-week window allotted. Members also have the right to vote to repeal a policy enacted.

--- a/content/fedlex/2022-001.md
+++ b/content/fedlex/2022-001.md
@@ -1,7 +1,7 @@
 +++
 title= "2022-001: The Rights and Obligations of Farer Members"
 date= "2022-11-09"
-updated= "2022-11-10"
+updated= "2022-12-04"
 +++
 
 ## Rights of Farer Members


### PR DESCRIPTION
Yesterday, Jack mentioned the possibility of adding membership fees. Its purpose would be to have a pool for Farer staff to utilise for paying for servers, investing money in exchange for time to develop for services, and obtaining 501(c)(3) status via a fiscal sponsorship from « Hack Club. »

This amendment would block the requirement of members needing to contribute to Farer monetarily to access services. 