### PR TITLE
Amend 2022-003 to require Ed25519 SSH keys

### DIFF
--- a/content/fedlex/2022-003.fr.md
+++ b/content/fedlex/2022-003.fr.md
@@ -1,7 +1,7 @@
 +++
 title= "2022-003: Promesse de sécurité et de confidentialité"
 date= "2022-11-10"
-updated= "2022-11-22"
+updated= "2022-12-29"
 +++
 
 Cette politique réglemente le niveau minimum de mesures de sécurité et de confidentialité sur les serveurs utilisés par The Farer Group ou les services utilisant le service d’authentification de Farer pour fournir des services aux membres de Farer. Son but ultime est de :
@@ -13,6 +13,8 @@ Les services DNS racine sont fournis par FarerNIC ou `dns.fa` / `nic.fa` pour le
 
 ## Protections de connexion
 Les serveurs doivent supprimer l’authentification par mot de passe, sauf si elle est accompagnée d’une méthode de clé matérielle à second facteur. En l’absence d’authentification par mot de passe, l’accès SSH doit être fourni à l’aide de clés SSH. Les clés matérielles de second facteur sont requises pour les serveurs gérés par The Farer Group et fortement recommandées pour les autres parties concernées par cette politique.
+
+Les clés SSH ne doivent pas utiliser le format RSA ou DSA. Les clés doivent utiliser le schéma de signature Ed25519 ou un format de sécurité égale ou supérieure. Ces clés doivent avoir au moins 4096 bits.
 
 ## Protections pare-feu
 Les serveurs doivent maintenir un pare-feu strict et une liste de contrôle d’accès pour :

--- a/content/fedlex/2022-003.md
+++ b/content/fedlex/2022-003.md
@@ -14,6 +14,8 @@ Root DNS services are provided by FarerNIC or `dns.fa`/`nic.fa` for Farer member
 ## Login protections
 Servers must remove password-based authentication unless accompanied by a second-factor hardware key method. In absence of password-based authentication, SSH access should be provided using SSH keys. Second-factor hardware keys are requried for servers run by The Farer Group and highly recommended for other parties affected by this policy.
 
+SSH keys must not use the RSA or DSA format. Keys must use the Ed25519 signature scheme or a format of equal or greater security. These keys must be 4096 bit at minimum.
+
 ## Firewall protections
 Servers should maintain a strict firewall and Access-Control List to:
   - prevent all users, but server administrations, from accessing remote control ports (such as SSH),

--- a/content/fedlex/2022-003.md
+++ b/content/fedlex/2022-003.md
@@ -1,7 +1,7 @@
 +++
 title= "2022-003: Digital Security and Privacy Promise"
 date= "2022-11-10"
-updated= "2022-11-22"
+updated= "2022-12-28"
 +++
 
 This policy regulates the minimum level of security and privacy measures on servers used by The Farer Group or services using Farer's Authentication Service to provide services to Farer members. It's ultimate intent is to:


### PR DESCRIPTION
Forgot to add this during the original policy write. We already do this in practice (that is, prefering or only using Ed25519), so it makes sense to make it the case on paper as well.

This amendment would require Ed25519 SSH keys to be used, rather than RSA or DSA keys, for servers affected by 2022-003. A translation will be made after both reviews are approved— do not merge until then.