### PR TITLE
Amend 2022-004 to use the proper server tagging methods in examples

### DIFF
--- a/content/fedlex/2022-004.fr.md
+++ b/content/fedlex/2022-004.fr.md
@@ -1,6 +1,7 @@
 +++
 title= "2022-004 : Schéma d’étiquetage des serveurs pour les emplacements"
 date = "2022-11-22"
+updated= 2022-12-29
 +++
 
 Les serveurs détenus ou maintenus par The Farer Group, exécutant des services officiels, ou fournissant un "noeud de sortie" dans Tailscale sont tenus de suivre cette convention pour marquer les serveurs par leur emplacement via Tailscale et via FarerNIC.
@@ -29,9 +30,9 @@ Lorsqu’un serveur est ajouté en tant que serveur DNS, c’est A record avec d
 Les membres seront en mesure d’utiliser ces balises pour avoir une idée générale de l’emplacement d’un serveur pour prendre une décision éclairée lors de son choix comme emplacement DNS, "noeud de sortie", ou autre utilisation via les services. Il permet aux utilisateurs de refuser plus facilement certaines régions pour que les données soient reflétées.
 
 ## Ajout d’exemples
-- Serveur situé à San Diego, aux États-Unis, appelé « rilakkuma » : « US-SOCAL-rilakkuma »
-- Serveur situé à San Francisco, aux États-Unis appelé « kiwi » : « US-NCAL-kiwi » (après NoCal vs SoCal)
-- Serveur situé dans le district de Columbia, aux États-Unis, appelé « whitehouse » : « US-DC-whitehouse »
-- Serveur situé à Paris, en France, appelé « eurostar » : « FR75-eurostar »
-- Serveur situé à Tokyo, au Japon, appelé « michiru » : « JP13-michiru »
-- Serveur situé à Hong Kong SAR, en Chine, appelé « weixin » : « CN-HKSAR-weixin »
+- Serveur situé à San Diego, aux États-Unis, appelé « rilakkuma »: « US-KSAN-rilakkuma »
+- Serveur situé à San Francisco, aux États-Unis appelé « kiwi »: « US-KSFO-kiwi »
+- Serveur situé dans le district de Columbia, aux États-Unis, appelé « whitehouse »: « US-KIAD-whitehouse »
+- Serveur situé à Paris, en France, appelé « eurostar »: « FR75-eurostar »
+- Serveur situé à Tokyo, au Japon, appelé « michiru »: « JP13-michiru »
+- Serveur situé à Hong Kong SAR, en Chine, appelé « weixin »: « CN-HKG-weixin » (« HKG » est le recommandation de Hongkong Post pour postals)

--- a/content/fedlex/2022-004.md
+++ b/content/fedlex/2022-004.md
@@ -1,6 +1,7 @@
 +++
 title= "2022-004: Server Tagging Scheme for Locations"
 date= "2022-11-22"
+updated= "2022-12-29"
 +++
 
 Servers owned or maintained by The Farer Group, running official services, or providing an "exit node" in Tailscale are obligated to follow this convention for tagging servers by their location via Tailscale and via FarerNIC.

--- a/content/fedlex/2022-004.md
+++ b/content/fedlex/2022-004.md
@@ -29,10 +29,10 @@ When a server is added as a DNS server, it's A record with `dns.nic.fa` will be 
 Members will be able to use these tags to get a general idea of the location of a server to make an informed decision when choosing it as a DNS location, "exit node", or other usage through services. It makes it easier for users to also opt-out of certain regions for data to be mirrored to.
 
 ## Addendum of examples
-- Server locatted in San Diego, U.S.A. called `rilakkuma`: `US-SOCAL-rilakkuma`
-- Server located in San Francisco, U.S.A. called `kiwi`: `US-NCAL-kiwi` (after NoCal vs SoCal)
-- Server located in the District of Columbia, U.S.A. called `whitehouse`: `US-DC-whitehouse`
+- Server locatted in San Diego, U.S.A. called `rilakkuma`: `US-KSAN-rilakkuma`
+- Server located in San Francisco, U.S.A. called `kiwi`: `US-KSFO-kiwi`
+- Server located in the District of Columbia, U.S.A. called `whitehouse`: `US-KIAD-whitehouse`
 - Server located in Paris, France called `eurostar`: `FR75-eurostar`
 - Server located in Tokyo, Japan called `michiru`: `JP13-michiru`
-- Server located in Hong Kong SAR, China called `weixin`: `CN-HKSAR-weixin`
+- Server located in Hong Kong SAR, China called `weixin`: `CN-HKG-weixin` (HKG is what Hongkong Post recommendes for postal codes)
 


### PR DESCRIPTION
2022-004 currently uses the old standard for tagging servers (based on location abbreviations such as `SOCAL` or `WINDY`).

This amendment would fix these improper server tags. Votes are not needed, but a sanity check is always encouraged.